### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -237,7 +237,7 @@ class syntax_plugin_sviewer extends DokuWiki_Syntax_Plugin {
     }
   }
   // Render
-  function render($mode, &$renderer, $data){
+  function render($mode, Doku_Renderer $renderer, $data){
     if ($mode!='xhtml') return false;
     global $conf;
     list($state, $match) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
